### PR TITLE
Registration fix

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,7 +7,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       session[:user_id] = @user.id
-      flash[:notice] = "Welcome, #{@user.first_name}!"
+      flash[:notice] = "Your account has successfully been created, #{@user.first_name}."
       redirect_to '/dashboard'
     else
       flash[:error] = @user.errors.full_messages.to_sentence

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,16 +8,16 @@
     <%= javascript_include_tag 'application' %>
   </head>
 
-  <body>
-    <main>
-      <%= yield %>
-    </main>
-
-    <% flash.each do |name, msg| %>
+  <% flash.each do |name, msg| %>
     <div class= "<%=name%>-flash">
       <p><%= msg %></p>
     </div>
   <% end %>
+
+  <body>
+    <main>
+      <%= yield %>
+    </main>
 
     <footer>
       <img src="https://www.themoviedb.org/assets/2/v4/logos/v2/blue_square_2-d537fb228cf3ded904ef09b136fe3fec72548ebc1fea3fbbd1ad9e36364db38b.svg" alt="The MovieDB Logo" width="75px" style="margin:10px" >

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -41,7 +41,7 @@ describe 'User Registration' do
       fill_in 'Password confirmation', with: 'password'
 
       click_button 'Register'
-save_and_open_page
+
       expect(page).to have_content("Email has already been taken")
     end
 

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -14,7 +14,7 @@ describe 'User Registration' do
       click_button 'Register'
 
       expect(current_path).to eq('/dashboard')
-      expect(page).to have_content('Welcome, Sam!')
+      expect(page).to have_content('Your account has successfully been created, Sam.')
     end
 
     it 'displays an error if any required field is left blank' do
@@ -41,7 +41,7 @@ describe 'User Registration' do
       fill_in 'Password confirmation', with: 'password'
 
       click_button 'Register'
-
+save_and_open_page
       expect(page).to have_content("Email has already been taken")
     end
 


### PR DESCRIPTION
This PR will:
- Update flash message to be specific about creating an account
- Move flash messages above body of page
- All tests passing (except intentionally skipped)

closes #14 